### PR TITLE
feat: Add easy OpenCode migration trigger for existing code agents

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect-agent
-description: "Use this skill ONLY when user explicitly requests: (1) 'write instructions for code agent' or 'create instructions', (2) 'this is a new architect agent, help me set it up' or 'initialize architect agent workspace', or (3) 'grade the code agent's work'. This skill creates delegation instructions, initializes architect agent workspaces with required directory structure, and grades completed work."
+description: "Use this skill ONLY when user explicitly requests: (1) 'write instructions for code agent' or 'create instructions', (2) 'this is a new architect agent, help me set it up' or 'initialize architect agent workspace', (3) 'grade the code agent's work', (4) 'send instructions to code agent', or (5) 'migrate code agent to also support OpenCode'. This skill creates delegation instructions, initializes workspaces, grades completed work, sends instructions, and adds OpenCode support to existing code agents."
 ---
 
 # Architect Agent Workflow Skill
@@ -35,7 +35,7 @@ Transform an AI agent into a specialized architect agent that plans, delegates i
 - **If directories missing**: Inform user this is not an architect agent workspace
 - **Action**: Review logs, apply grading rubric, create grade file
 
-**Trigger 4: User requests sending instructions to code agent** ⭐ NEW
+**Trigger 4: User requests sending instructions to code agent** ⭐
 - User says: "send instructions to code agent"
 - User says: "send these instructions" or "send them"
 - **Prerequisite Check**:
@@ -49,6 +49,26 @@ Transform an AI agent into a specialized architect agent that plans, delegates i
   ```
 - **Why keep it simple**: File copy is trivial, doesn't need agent processing, wastes tokens
 - **See**: `references/instruction_grading_workflow.md` for complete protocol
+
+**Trigger 5: User requests OpenCode migration** ✨ NEW
+- User says: "migrate code agent to also support OpenCode"
+- User says: "add OpenCode support to code agent"
+- User says: "install OpenCode hooks on code agent"
+- **Prerequisite Check**:
+  - Verify code agent workspace path is known/configured
+  - Verify code agent workspace has `.claude/hooks.json` (Claude Code setup)
+- **If prerequisites missing**: Ask user for code agent workspace path
+- **Action**: Execute migration workflow (see below)
+- **Migration adds**:
+  - OpenCode TypeScript plugin (`.opencode/plugins/logger/`)
+  - OpenCode configuration (`.opencode/opencode.json`)
+  - Wrapper scripts (optional, `debugging/wrapper-scripts/`)
+  - Session management scripts (`debugging/scripts/log-start.sh`, `log-complete.sh`)
+- **Preserves**:
+  - Existing `.claude/hooks.json` (dual-mode support)
+  - All existing logs and scripts
+  - No breaking changes
+- **See**: Migration workflow section below for detailed steps
 
 **DO NOT trigger this skill for:**
 - General architecture discussions
@@ -283,6 +303,155 @@ Save grade at: `grades/grade-YYYY_MM_DD-HH_MM-same_description.md`
 - Architect Agent 2: `/Users/user/architect/project-b` → Code Agent: `/Users/user/projects/project-b`
 
 Each architect agent maintains its own `instructions/`, `grades/`, `human/`, and `ticket/` directories while referencing different code agent workspaces.
+
+## OpenCode Migration Workflow (Trigger 5)
+
+When user requests "migrate code agent to also support OpenCode", execute this workflow:
+
+### Step 1: Verify Prerequisites
+
+```bash
+# Check code agent workspace exists
+CODE_AGENT_WS="/path/to/code/agent/workspace"
+[ -d "$CODE_AGENT_WS" ] || { echo "Code agent workspace not found"; exit 1; }
+
+# Check Claude Code setup exists
+[ -f "$CODE_AGENT_WS/.claude/hooks.json" ] || echo "⚠️  Warning: No Claude Code hooks found. This may be a fresh workspace."
+
+# Check if OpenCode already installed
+[ -d "$CODE_AGENT_WS/.opencode/plugins/logger" ] && echo "✓ OpenCode already installed" && exit 0
+```
+
+### Step 2: Copy OpenCode Plugin
+
+```bash
+# Copy TypeScript plugin
+mkdir -p "$CODE_AGENT_WS/.opencode/plugins"
+cp -r ~/.claude/skills/architect-agent/templates/opencode/plugins/logger \
+      "$CODE_AGENT_WS/.opencode/plugins/"
+
+# Create opencode.json configuration
+cp ~/.claude/skills/architect-agent/templates/opencode/opencode.json \
+   "$CODE_AGENT_WS/.opencode/"
+
+echo "✓ OpenCode plugin installed"
+```
+
+### Step 3: Add Session Management Scripts
+
+```bash
+# Create session management scripts (replaces /log-start and /log-complete)
+cat > "$CODE_AGENT_WS/debugging/scripts/log-start.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+DESCRIPTION=${1:-"session"}
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="debugging/logs/log-${TIMESTAMP}-${DESCRIPTION}.md"
+mkdir -p debugging/logs
+cat > "$LOG_FILE" <<LOGEOF
+# Log Session: $DESCRIPTION
+**Started:** $(date '+%Y-%m-%d %H:%M:%S')
+
+## Goal
+[Document your goal here]
+
+## Success Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+---
+
+LOGEOF
+echo "$LOG_FILE" > debugging/current_log_file.txt
+echo "✅ Log session started: $LOG_FILE"
+EOF
+
+cat > "$CODE_AGENT_WS/debugging/scripts/log-complete.sh" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+if [ ! -f debugging/current_log_file.txt ]; then
+    echo "❌ Error: No active log session"
+    exit 1
+fi
+LOG_FILE=$(cat debugging/current_log_file.txt)
+TIMESTAMP="[$(date +%H:%M:%S)]"
+cat >> "$LOG_FILE" <<LOGEOF
+
+---
+$TIMESTAMP 🏁 Final Summary
+**Status:** ✅ COMPLETE
+**Completed:** $(date '+%Y-%m-%d %H:%M:%S')
+---
+LOGEOF
+echo "✅ Log session completed: $LOG_FILE"
+rm debugging/current_log_file.txt
+EOF
+
+chmod +x "$CODE_AGENT_WS/debugging/scripts/log-start.sh"
+chmod +x "$CODE_AGENT_WS/debugging/scripts/log-complete.sh"
+
+echo "✓ Session management scripts created"
+```
+
+### Step 4: Optional Wrapper Scripts
+
+```bash
+# Copy wrapper scripts (for users who prefer bash over TypeScript plugin)
+mkdir -p "$CODE_AGENT_WS/debugging/wrapper-scripts"
+cp ~/.claude/skills/architect-agent/templates/opencode/wrapper-scripts/*.sh \
+   "$CODE_AGENT_WS/debugging/wrapper-scripts/"
+chmod +x "$CODE_AGENT_WS/debugging/wrapper-scripts/"*.sh
+
+echo "✓ Wrapper scripts installed (optional alternative to plugin)"
+```
+
+### Step 5: Verify Installation
+
+```bash
+# Check all components installed
+echo ""
+echo "✅ OpenCode Migration Complete!"
+echo ""
+echo "Installed:"
+echo "  ✓ TypeScript plugin: .opencode/plugins/logger/"
+echo "  ✓ Configuration: .opencode/opencode.json"
+echo "  ✓ Session scripts: debugging/scripts/log-start.sh, log-complete.sh"
+echo "  ✓ Wrapper scripts: debugging/wrapper-scripts/ (optional)"
+echo ""
+echo "Preserved:"
+echo "  ✓ Claude Code hooks: .claude/hooks.json"
+echo "  ✓ Existing logs: debugging/logs/"
+echo "  ✓ Decision script: debugging/scripts/log-decision.sh"
+echo ""
+echo "Code agent now supports BOTH Claude Code AND OpenCode!"
+echo ""
+echo "Usage for OpenCode:"
+echo "  ./debugging/scripts/log-start.sh \"task-description\""
+echo "  # Work normally - plugin logs automatically"
+echo "  ./debugging/scripts/log-complete.sh"
+echo ""
+```
+
+### Migration Notes for User
+
+After migration, inform user:
+
+> **✅ Migration Complete!**
+>
+> Your code agent workspace now supports **both Claude Code and OpenCode**:
+>
+> **For Claude Code** (no changes needed):
+> - Continue using `/log-start`, `/log-checkpoint`, `/log-complete`
+> - Hooks in `.claude/hooks.json` still active
+>
+> **For OpenCode** (new capability):
+> - Use `./debugging/scripts/log-start.sh "description"`
+> - Plugin logs automatically (same as Claude Code hooks)
+> - Use `./debugging/scripts/log-complete.sh` to finish
+>
+> **Same log format, same token savings (60-70%), same grading rubric.**
+>
+> See `references/opencode_logging_protocol.md` for complete OpenCode usage.
 
 ## Permissions Setup (CRITICAL for Smooth Operation)
 


### PR DESCRIPTION
## Fixes #9

## Problem

Users with existing Claude Code-based code agent workspaces need an easy way to add OpenCode support without breaking their current setup or manually copying template files.

## Solution

Added new **Trigger 5** to the architect-agent skill:

**User says:** "migrate code agent to also support OpenCode"  
**Architect does:** Automated 5-step migration workflow

## What The Migration Does

### ✅ Adds (Non-Destructive)
1. **TypeScript Plugin** → `.opencode/plugins/logger/`
2. **OpenCode Config** → `.opencode/opencode.json`
3. **Session Scripts** → `debugging/scripts/log-start.sh`, `log-complete.sh`
4. **Wrapper Scripts** → `debugging/wrapper-scripts/` (optional)

### ✅ Preserves (No Changes)
- Existing `.claude/hooks.json` (Claude Code still works)
- All existing logs in `debugging/logs/`
- Decision logging script `log-decision.sh`
- All code and project files

## Changes Made

### SKILL.md Updates

**1. New Trigger Added:**


**2. Complete Migration Workflow:**
- Step 1: Verify Prerequisites
- Step 2: Copy OpenCode Plugin
- Step 3: Add Session Management Scripts
- Step 4: Optional Wrapper Scripts
- Step 5: Verify Installation

**3. Updated Skill Description:**
Added migration trigger as 5th explicit trigger point

## Workflow Details

### Step 1: Verify Prerequisites
- Check code agent workspace exists
- Verify Claude Code setup present (warning if missing)
- Skip if OpenCode already installed

### Step 2: Copy OpenCode Plugin


### Step 3: Session Management
Creates bash scripts that replace OpenCode's missing slash commands:
- `log-start.sh "description"` → replaces `/log-start`
- `log-complete.sh` → replaces `/log-complete`

### Step 4: Wrapper Scripts (Optional)
Provides bash alternative to TypeScript plugin for users who prefer it

### Step 5: Verification
Displays summary of installed vs preserved components

## Benefits

✅ **One Command** - User says migration phrase, architect handles everything  
✅ **Safe** - Only adds files, never modifies or removes existing setup  
✅ **Dual-Mode** - Code agent works with BOTH Claude Code AND OpenCode  
✅ **Clear** - Inline bash scripts, no external dependencies  
✅ **Tested** - Workflow proven in OpenCode integration tests

## User Experience

**Before Migration (Claude Code only):**


**After Migration (Dual-Mode):**


## Testing

- ✅ Workflow tested manually
- ✅ Bash scripts validated
- ✅ File paths verified
- ✅ Non-destructive verified (preserves Claude Code setup)

## Impact

- **No breaking changes** to existing Claude Code workflows
- **Enables gradual adoption** of OpenCode
- **Reduces barrier** to trying OpenCode
- **Maintains compatibility** - users can switch back and forth

## Next Steps

After merge, users can:
1. Say "migrate code agent to also support OpenCode" to architect
2. Architect runs automated migration
3. Code agent immediately supports OpenCode
4. No manual file copying or configuration needed