### PR TITLE
added commands, scripts, etc. that were missing from the proejct and …

### DIFF
--- a/references/claude_vs_opencode_comparison.md
+++ b/references/claude_vs_opencode_comparison.md
@@ -11,9 +11,9 @@ Both **Claude Code** (Anthropic's official CLI) and **OpenCode** (open-source al
 
 - **Claude Code** → Official support, built-in features, simpler setup
 - **OpenCode** → Open source, customizable, community-driven
-- **Hybrid** → Architect uses Claude Code, Code Agent uses OpenCode (best of both)
+- **Hybrid** → Mix and match! A single project can have code agents using Claude Code alongside code agents using OpenCode
 
-**Bottom Line:** The architect-agent skill provides full compatibility with both tools through the hybrid logging protocol v2.0.
+**Bottom Line:** The architect-agent skill provides full compatibility with both tools through the hybrid logging protocol v2.0. Both tools now have slash command parity (same format, different directory locations).
 
 ---
 
@@ -24,7 +24,7 @@ Both **Claude Code** (Anthropic's official CLI) and **OpenCode** (open-source al
 | **Open Source** | ❌ Proprietary | ✅ Fully open | OpenCode |
 | **Official Support** | ✅ Anthropic-backed | ⚠️ Community | Claude Code |
 | **Automated Logging** | ✅ hooks.json | ✅ Plugin/wrappers | Tie |
-| **Slash Commands** | ✅ Built-in | ❌ Manual scripts | Claude Code |
+| **Slash Commands** | ✅ `.claude/commands/` | ✅ `.opencode/command/` | Tie |
 | **Customizability** | ⚠️ Limited | ✅ Full control | OpenCode |
 | **Setup Complexity** | ✅ Simpler | ⚠️ More steps | Claude Code |
 | **Performance (logging)** | ✅ Fast hooks | ✅ Fast plugin | Tie |
@@ -101,13 +101,15 @@ export default definePlugin({
 
 #### Claude Code
 
-**Built-in Slash Commands:**
+**Slash Commands (built-in):**
 
 ```bash
 /log-start          # Start new log session
 /log-checkpoint     # Manual milestone
 /log-complete       # Complete session
 ```
+
+**Command Directory:** `.claude/commands/`
 
 **Pros:**
 - Zero setup required
@@ -121,7 +123,17 @@ export default definePlugin({
 
 #### OpenCode
 
-**Bash Scripts:**
+**Slash Commands (now supported!):**
+
+```bash
+/log-start          # Start new log session
+/log-checkpoint     # Manual milestone
+/log-complete       # Complete session
+```
+
+**Command Directory:** `.opencode/command/`
+
+**Alternative - Bash Scripts:**
 
 ```bash
 ./debugging/scripts/log-start.sh "task-description"
@@ -129,16 +141,15 @@ export default definePlugin({
 ```
 
 **Pros:**
-- Fully customizable (edit bash scripts)
+- **Slash commands now work identically to Claude Code**
+- Fully customizable (edit markdown files or bash scripts)
 - Transparent (readable implementation)
 - Can add custom logic (notifications, integrations, etc.)
 
 **Cons:**
-- Requires creating/maintaining scripts
-- No built-in commands
-- Manual setup per workspace
+- Requires copying command files (templates provided)
 
-**Verdict:** **Claude Code wins on convenience**, **OpenCode wins on flexibility**
+**Verdict:** **Tie** - Both now have slash command parity. OpenCode still wins on customization.
 
 ---
 
@@ -375,12 +386,14 @@ export default definePlugin({
 
 ✅ **Architect agent** → Claude Code (benefits from slash commands)
 ✅ **Code agent** → OpenCode (open source, customizable)
+✅ **Multiple code agents** → Mix of Claude Code and OpenCode in the same project!
 
 **Benefits:**
 - Architect gets simple UX with built-in commands
 - Code agent gets customization and open-source benefits
 - Both use same log format (grading compatible)
 - Best of both worlds
+- **A single project can use both types of code agents** - some team members can use Claude Code while others use OpenCode
 
 **Example Workflow:**
 ```

--- a/references/opencode_migration_guide.md
+++ b/references/opencode_migration_guide.md
@@ -33,8 +33,8 @@
 
 ✅ **Official Support** - Maintained by Anthropic
 ✅ **Native Integration** - Built specifically for Claude
-✅ **Slash Commands** - `/log-start`, `/log-checkpoint`, `/log-complete` built-in
-✅ **Simpler Setup** - Hooks.json vs TypeScript plugin
+✅ **Slash Commands** - Both tools now support slash commands (same format!)
+✅ **Simpler Setup** - Hooks.json vs JavaScript plugin
 ✅ **Documentation** - Official Claude Code documentation
 
 ### Hybrid Approach (Best of Both)
@@ -54,11 +54,22 @@ This guide focuses on migrating the **code agent workspace** from Claude Code �
 
 | Claude Code | OpenCode Equivalent | Action |
 |------------|-------------------|--------|
-| `.claude/hooks.json` | `.opencode/plugins/logger/index.ts` OR `debugging/wrapper-scripts/*.sh` | Remove `.claude/hooks.json`, add plugin or wrappers |
+| `.claude/hooks.json` | `.opencode/plugin/logger.js` OR `debugging/wrapper-scripts/*.sh` | Remove `.claude/hooks.json`, add plugin or wrappers |
 | `.claude/settings.local.json` | OpenCode-specific permissions config | Update permissions syntax (consult OpenCode docs) |
-| `/log-start` slash command | `./debugging/scripts/log-start.sh` | Create bash script |
-| `/log-checkpoint` slash command | `./debugging/scripts/log-decision.sh milestone` | Use milestone type |
-| `/log-complete` slash command | `./debugging/scripts/log-complete.sh` | Create bash script |
+| `.claude/commands/*.md` | `.opencode/command/*.md` | Copy slash commands (same format, different directory) |
+| `/log-start` slash command | `/log-start` OR `./debugging/scripts/log-start.sh` | OpenCode now has native slash commands too! |
+| `/log-checkpoint` slash command | `/log-checkpoint` OR `./debugging/scripts/log-decision.sh milestone` | Use slash command or script |
+| `/log-complete` slash command | `/log-complete` OR `./debugging/scripts/log-complete.sh` | Use slash command or script |
+
+### Slash Command Parity (NEW)
+
+**OpenCode now supports slash commands!** The directory structure differs slightly:
+
+| Claude Code | OpenCode |
+|------------|----------|
+| `.claude/commands/` | `.opencode/command/` |
+
+The file format is identical (markdown with optional YAML frontmatter). The templates now include pre-configured OpenCode slash commands that mirror Claude Code's commands exactly.
 
 ### Behavioral Changes
 

--- a/templates/architect-workspace/.opencode/command/instruct.md
+++ b/templates/architect-workspace/.opencode/command/instruct.md
@@ -1,0 +1,31 @@
+---
+description: Review instruction summary before sending to code agent
+---
+# /project.instruct - Review Instruction Summary
+
+Read the most recent instruction file from the `instructions/` directory and create a concise 10-25 bullet point summary showing:
+
+## Summary Format:
+
+**Main Objectives:**
+- [Key goal 1]
+- [Key goal 2]
+
+**Key Requirements:**
+- [Critical requirement 1]
+- [Critical requirement 2]
+
+**Critical Constraints:**
+- [Constraint 1]
+- [Constraint 2]
+
+**Success Criteria:**
+- [How to verify success 1]
+- [How to verify success 2]
+
+**Testing Requirements:**
+- [Test 1]
+- [Test 2]
+
+Display this summary to help review what will be sent to the code agent.
+

--- a/templates/architect-workspace/.opencode/command/send.md
+++ b/templates/architect-workspace/.opencode/command/send.md
@@ -1,0 +1,36 @@
+---
+description: Send instructions to code agent workspace
+---
+# /project.send - Send Instructions to Code Agent
+
+Perform the following steps to send instructions to the code agent:
+
+## Steps:
+
+### 1. Identify Files
+- Find the most recent instruction file in `instructions/instruct-*.md`
+- Find the corresponding human summary in `human/human-*.md` (matching timestamp)
+
+### 2. Copy Instruction
+Copy the instruction file to code agent's canonical location:
+```
+[PATH_TO_CODE_AGENT_WORKSPACE]/debugging/instructions/current_instruction.md
+```
+
+### 3. Display Human Summary
+Read the corresponding human summary and display the 10-25 bullet points to the user showing:
+- Main objectives
+- Key requirements
+- Critical constraints
+- Success criteria
+- Testing requirements
+
+### 4. Confirm
+Report to user:
+```
+✅ Instructions sent to code agent
+📄 File: current_instruction.md
+📍 Location: [PATH_TO_CODE_AGENT_WORKSPACE]/debugging/instructions/
+
+Summary shown above. Code agent can now be started to execute these instructions.
+```

--- a/templates/architect-workspace/.opencode/opencode.json
+++ b/templates/architect-workspace/.opencode/opencode.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+}

--- a/templates/architect-workspace/scripts/tail-code-agent-logs.sh
+++ b/templates/architect-workspace/scripts/tail-code-agent-logs.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# tail-code-agent-logs.sh - Watch code agent logs in real-time
+#
+# Usage:
+#   ./tail-code-agent-logs.sh           # Tail active log (from current_log_file.txt)
+#   ./tail-code-agent-logs.sh --latest  # Tail most recently modified log
+#   ./tail-code-agent-logs.sh --all     # Tail all logs (newest first)
+#   ./tail-code-agent-logs.sh --list    # List available logs
+#   ./tail-code-agent-logs.sh <file>    # Tail specific log file
+#
+
+set -euo pipefail
+
+# Configuration
+CODE_AGENT_DIR="${CODE_AGENT_DIR:-[PATH_TO_CODE_AGENT_WORKSPACE]}"
+LOGS_DIR="$CODE_AGENT_DIR/debugging/logs"
+CURRENT_LOG_PTR="$CODE_AGENT_DIR/debugging/current_log_file.txt"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+print_header() {
+    echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║${NC}  ${BOLD}Code Agent Log Viewer${NC}                                     ${BLUE}║${NC}"
+    echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+}
+
+print_usage() {
+    echo -e "${BOLD}Usage:${NC}"
+    echo "  $0              # Tail active log (from current_log_file.txt)"
+    echo "  $0 --latest     # Tail most recently modified log"
+    echo "  $0 --all        # Tail all logs (newest first)"
+    echo "  $0 --list       # List available logs"
+    echo "  $0 <file>       # Tail specific log file"
+    echo ""
+    echo -e "${BOLD}Environment:${NC}"
+    echo "  CODE_AGENT_DIR  # Override code agent directory"
+}
+
+list_logs() {
+    print_header
+    echo -e "${BOLD}Available Logs:${NC}"
+    echo ""
+
+    if [[ ! -d "$LOGS_DIR" ]]; then
+        echo -e "${RED}Error: Logs directory not found: $LOGS_DIR${NC}"
+        exit 1
+    fi
+
+    local active_log=""
+    if [[ -f "$CURRENT_LOG_PTR" ]]; then
+        active_log=$(cat "$CURRENT_LOG_PTR" 2>/dev/null || echo "")
+    fi
+
+    # List logs sorted by modification time (newest first)
+    while IFS= read -r file; do
+        local basename=$(basename "$file")
+        local mod_time=$(stat -f "%Sm" -t "%Y-%m-%d %H:%M" "$file" 2>/dev/null || stat -c "%y" "$file" 2>/dev/null | cut -d'.' -f1)
+        local size=$(du -h "$file" 2>/dev/null | cut -f1)
+
+        if [[ "$file" == *"$active_log"* ]] || [[ "$active_log" == *"$basename"* ]]; then
+            echo -e "  ${GREEN}▶${NC} ${BOLD}$basename${NC} ${GREEN}(ACTIVE)${NC}"
+        else
+            echo -e "    $basename"
+        fi
+        echo -e "      ${CYAN}Modified:${NC} $mod_time  ${CYAN}Size:${NC} $size"
+    done < <(find "$LOGS_DIR" -name "*.md" -type f -exec ls -t {} + 2>/dev/null)
+
+    echo ""
+}
+
+get_active_log() {
+    if [[ -f "$CURRENT_LOG_PTR" ]]; then
+        local ptr=$(cat "$CURRENT_LOG_PTR" 2>/dev/null || echo "")
+        if [[ -n "$ptr" ]]; then
+            # Handle both relative and absolute paths
+            if [[ "$ptr" == /* ]]; then
+                echo "$ptr"
+            else
+                echo "$CODE_AGENT_DIR/$ptr"
+            fi
+            return 0
+        fi
+    fi
+    return 1
+}
+
+get_latest_log() {
+    find "$LOGS_DIR" -name "*.md" -type f -exec ls -t {} + 2>/dev/null | head -1
+}
+
+tail_log() {
+    local log_file="$1"
+    local basename=$(basename "$log_file")
+
+    print_header
+    echo -e "${BOLD}Tailing:${NC} ${CYAN}$basename${NC}"
+    echo -e "${BOLD}Full Path:${NC} $log_file"
+    echo -e "${YELLOW}Press Ctrl+C to stop${NC}"
+    echo ""
+    echo -e "${BLUE}────────────────────────────────────────────────────────────────${NC}"
+    echo ""
+
+    # Use tail -f with some context
+    tail -n 50 -f "$log_file" 2>/dev/null || {
+        echo -e "${RED}Error: Cannot tail file: $log_file${NC}"
+        exit 1
+    }
+}
+
+tail_all_logs() {
+    print_header
+    echo -e "${BOLD}Tailing all logs (newest activity first)${NC}"
+    echo -e "${YELLOW}Press Ctrl+C to stop${NC}"
+    echo ""
+    echo -e "${BLUE}────────────────────────────────────────────────────────────────${NC}"
+    echo ""
+
+    # Use tail -f on all markdown log files
+    local files=$(find "$LOGS_DIR" -name "*.md" -type f 2>/dev/null)
+    if [[ -z "$files" ]]; then
+        echo -e "${RED}No log files found in $LOGS_DIR${NC}"
+        exit 1
+    fi
+
+    # tail -f with file headers
+    tail -n 20 -f $files 2>/dev/null || {
+        echo -e "${RED}Error tailing log files${NC}"
+        exit 1
+    }
+}
+
+# Main
+main() {
+    # Check if logs directory exists
+    if [[ ! -d "$LOGS_DIR" ]]; then
+        echo -e "${RED}Error: Code agent logs directory not found${NC}"
+        echo -e "Expected: $LOGS_DIR"
+        echo ""
+        echo -e "${YELLOW}Make sure CODE_AGENT_DIR is set correctly or the code agent has started logging.${NC}"
+        exit 1
+    fi
+
+    case "${1:-}" in
+        --help|-h)
+            print_header
+            print_usage
+            ;;
+        --list|-l)
+            list_logs
+            ;;
+        --all|-a)
+            tail_all_logs
+            ;;
+        --latest)
+            local latest=$(get_latest_log)
+            if [[ -z "$latest" ]]; then
+                echo -e "${RED}No log files found in $LOGS_DIR${NC}"
+                exit 1
+            fi
+            tail_log "$latest"
+            ;;
+        "")
+            # Default: tail active log or latest
+            local active=$(get_active_log || echo "")
+            if [[ -n "$active" ]] && [[ -f "$active" ]]; then
+                echo -e "${GREEN}Found active log session${NC}"
+                tail_log "$active"
+            else
+                echo -e "${YELLOW}No active log session found, using latest log${NC}"
+                local latest=$(get_latest_log)
+                if [[ -z "$latest" ]]; then
+                    echo -e "${RED}No log files found in $LOGS_DIR${NC}"
+                    exit 1
+                fi
+                tail_log "$latest"
+            fi
+            ;;
+        *)
+            # Specific file
+            local file="$1"
+            if [[ ! -f "$file" ]]; then
+                # Try in logs directory
+                file="$LOGS_DIR/$1"
+            fi
+            if [[ ! -f "$file" ]]; then
+                echo -e "${RED}Error: Log file not found: $1${NC}"
+                list_logs
+                exit 1
+            fi
+            tail_log "$file"
+            ;;
+    esac
+}
+
+main "$@"

--- a/templates/code-agent-workspace/.opencode/command/check.md
+++ b/templates/code-agent-workspace/.opencode/command/check.md
@@ -1,0 +1,41 @@
+---
+description: Review current instructions from architect agent
+---
+# /project.check - Review Current Instructions
+
+Read and summarize the current instruction file from the architect agent:
+
+```bash
+cat debugging/instructions/current_instruction.md
+```
+
+Then create a concise 10-25 bullet point summary showing:
+
+## Summary Format:
+
+**Main Objectives:**
+- [Key goal 1]
+- [Key goal 2]
+
+**Key Requirements:**
+- [Critical requirement 1]
+- [Critical requirement 2]
+
+**Critical Constraints:**
+- [Constraint 1]
+- [Constraint 2]
+
+**Success Criteria:**
+- [How to verify success 1]
+- [How to verify success 2]
+
+**Testing Requirements:**
+- [Test 1]
+- [Test 2]
+
+Display this summary to help understand what needs to be accomplished.
+
+**If no instruction file exists:**
+```
+No current instructions found at debugging/instructions/current_instruction.md
+```

--- a/templates/code-agent-workspace/.opencode/command/instruct.md
+++ b/templates/code-agent-workspace/.opencode/command/instruct.md
@@ -1,0 +1,44 @@
+---
+description: Review and execute current instructions from architect agent
+---
+# /project.instruct - Review Current Instructions
+
+Read and summarize the current instruction file from the architect agent:
+
+```bash
+cat debugging/instructions/current_instructions.md
+```
+
+Then create a concise 10-25 bullet point summary showing:
+
+## Summary Format:
+
+**Main Objectives:**
+- [Key goal 1]
+- [Key goal 2]
+
+**Key Requirements:**
+- [Critical requirement 1]
+- [Critical requirement 2]
+
+**Critical Constraints:**
+- [Constraint 1]
+- [Constraint 2]
+
+**Success Criteria:**
+- [How to verify success 1]
+- [How to verify success 2]
+
+**Testing Requirements:**
+- [Test 1]
+- [Test 2]
+
+Display this summary to help understand what needs to be accomplished.
+
+**If no instruction file exists:**
+```
+No current instructions found at debugging/instructions/current_instructions.md
+```
+
+# Start executing the instructions
+Now run the instructions

--- a/templates/code-agent-workspace/.opencode/command/log-checkpoint.md
+++ b/templates/code-agent-workspace/.opencode/command/log-checkpoint.md
@@ -1,0 +1,35 @@
+---
+description: Create a checkpoint in the current logging session
+---
+# /log-checkpoint - Create Checkpoint
+
+Create a checkpoint in the current logging session:
+
+```bash
+./debugging/scripts/log-checkpoint.sh "checkpoint-name"
+```
+
+**Example:**
+```bash
+./debugging/scripts/log-checkpoint.sh "tests-passing"
+```
+
+**What this does:**
+1. Adds a visual checkpoint marker to the log
+2. Includes timestamp and checkpoint name
+3. Helps organize log into logical sections
+
+**When to use:**
+- After completing a major step
+- Before starting a new phase of work
+- After tests pass
+- After fixing a bug
+- Before attempting risky changes
+
+**Checkpoint format in log:**
+```
+========================================
+CHECKPOINT: tests-passing
+TIME: 2025-11-20 14:30:45
+========================================
+```

--- a/templates/code-agent-workspace/.opencode/command/log-complete.md
+++ b/templates/code-agent-workspace/.opencode/command/log-complete.md
@@ -1,0 +1,33 @@
+---
+description: Complete the current logging session
+---
+# /log-complete - Complete Logging Session
+
+Complete the current logging session:
+
+```bash
+./debugging/scripts/log-complete.sh
+```
+
+**What this does:**
+1. Adds completion footer to log file
+2. Clears `debugging/current_log_file.txt` (stops hook logging)
+3. Finalizes the session
+
+**Session footer added:**
+```
+========================================
+SESSION COMPLETED
+TIME: 2025-11-20 14:45:30
+========================================
+```
+
+**After completion:**
+- Hooks stop logging (no active session)
+- Log file preserved in `debugging/logs/`
+- Ready to start new session with `/log-start`
+
+**Always complete sessions** to:
+- Mark clear end point in logs
+- Stop unnecessary hook logging
+- Keep logs organized

--- a/templates/code-agent-workspace/.opencode/command/log-start.md
+++ b/templates/code-agent-workspace/.opencode/command/log-start.md
@@ -1,0 +1,27 @@
+---
+description: Start a new logging session for work tracking
+---
+# /log-start - Start Logging Session
+
+Start a new logging session using the logging script:
+
+```bash
+./debugging/scripts/log-start.sh "brief description of work"
+```
+
+**Example:**
+```bash
+./debugging/scripts/log-start.sh "implement-alloydb-migration"
+```
+
+**What this does:**
+1. Creates new log file in `debugging/logs/session_YYYYMMDD_HHMMSS.log`
+2. Writes log file path to `debugging/current_log_file.txt`
+3. Hooks will now automatically capture tool calls to this log
+4. Adds session header with timestamp and description
+
+**After starting session:**
+- All tool calls automatically logged (if hooks working)
+- Add manual context with `./debugging/scripts/log-decision.sh`
+- Create checkpoints with `/log-checkpoint`
+- Complete session with `/log-complete`

--- a/templates/code-agent-workspace/.opencode/command/run.md
+++ b/templates/code-agent-workspace/.opencode/command/run.md
@@ -1,0 +1,13 @@
+---
+description: Run current instructions from architect agent
+---
+# /project.run - Run Current Instructions
+
+Read the current instruction file from the architect agent:
+
+```bash
+cat debugging/instructions/current_instruction.md
+```
+
+# Start executing the instructions
+Now run the instructions

--- a/templates/code-agent-workspace/.opencode/opencode.json
+++ b/templates/code-agent-workspace/.opencode/opencode.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://opencode.ai/config.json"
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["./plugin/logger.js"]
 }


### PR DESCRIPTION
added commands, scripts, etc. that were missing from the proejct and some that were just missing from the opencode version.

Closes #15 

---
This pull request updates documentation and templates to reflect new slash command parity between Claude Code and OpenCode, and introduces new OpenCode command templates and helper scripts for both architect and code agent workspaces. The changes ensure that both tools now support identical slash commands (with minor directory differences), improve migration instructions, and add example command files and utilities for OpenCode-based workflows.

**Documentation and Comparison Updates:**

- Updated the Claude Code vs. OpenCode comparison to reflect that both tools now support slash commands with identical formats, clarify directory differences, and emphasize hybrid usage (mixing both tools in one project). [[1]](diffhunk://#diff-ad813a3de4fd8767af50896275caf2ceb672766d8975eb3329ff06f67f6e3d63L14-R16) [[2]](diffhunk://#diff-ad813a3de4fd8767af50896275caf2ceb672766d8975eb3329ff06f67f6e3d63L27-R27) [[3]](diffhunk://#diff-ad813a3de4fd8767af50896275caf2ceb672766d8975eb3329ff06f67f6e3d63L104-R113) [[4]](diffhunk://#diff-ad813a3de4fd8767af50896275caf2ceb672766d8975eb3329ff06f67f6e3d63L124-R152) [[5]](diffhunk://#diff-ad813a3de4fd8767af50896275caf2ceb672766d8975eb3329ff06f67f6e3d63R389-R396)
- Improved the OpenCode migration guide to document slash command parity, update migration steps, and clarify plugin file names and directory structures. [[1]](diffhunk://#diff-35ba17bbf49374a798d11eab2da110981257f9ca82666a921c6e0d1dd7095a6cL36-R37) [[2]](diffhunk://#diff-35ba17bbf49374a798d11eab2da110981257f9ca82666a921c6e0d1dd7095a6cL57-R72)

**Architect Workspace (OpenCode) Additions:**

- Added new OpenCode slash command templates: `/project.instruct` (summary review), `/project.send` (send instructions), and OpenCode config file (`opencode.json`). [[1]](diffhunk://#diff-00afd22bffb80f067d118e07b3ac1b1d12671977bfa64bdc980c563d3f987e83R1-R31) [[2]](diffhunk://#diff-8830f1a6e16b64d07cd16757b93d4aa1b8ddbcfffe2488e30292b4e5a560b1cbR1-R36) [[3]](diffhunk://#diff-8503bac84acbc27b3c61012071666f9774748753a1844833567ebc08a61a5ffdR1-R3)
- Introduced a helper script `tail-code-agent-logs.sh` for real-time log viewing and management of code agent logs.

**Code Agent Workspace (OpenCode) Additions:**

- Added OpenCode slash command templates for reviewing and executing instructions (`/project.check`, `/project.instruct`, `/project.run`) and for logging workflow (`/log-start`, `/log-checkpoint`, `/log-complete`). [[1]](diffhunk://#diff-a7f847e53517d4f06987c584bd2e32418c53f4f31e96040d616609fa1707c648R1-R41) [[2]](diffhunk://#diff-531c0b4d718373a1130c530628cb891329b51fcd0623c07ba221344d5af79db9R1-R44) [[3]](diffhunk://#diff-284de288a6dfaacbfa8166025b141091814fa8b7992a1a08e8fa2c232384933cR1-R13) [[4]](diffhunk://#diff-a33c5b9b9bbf84995a10676d4984d922c6a3c646c26b40f189ddab3634c5d27aR1-R27) [[5]](diffhunk://#diff-742efcdf3ae443a5ddc5fdb20015af20c01275e57edddb6e99eefcca629c6062R1-R35) [[6]](diffhunk://#diff-bdfa0879c81947e1c4820ad32ffdaa4f1b205c6c5a02cb64b634aa106ac9373aR1-R33)
- Updated OpenCode config to load the logger plugin by default.

These changes make it much easier to migrate between Claude Code and OpenCode, enable teams to use both tools interchangeably, and provide ready-to-use command templates and utilities for OpenCode-based workflows.