### PR TITLE
feat: improve SKILL.md based on evaluation feedback

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,24 @@
 ---
 name: architect-agent
 description: Coordinates planning, delegation, and evaluation across architect and code agent workspaces. Use when asked to "write instructions for code agent", "initialize architect workspace", "grade code agent work", "send instructions", or "verify code agent setup".
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+  - Task
+metadata:
+  version: 3.1.0
+  last-updated: 2025-12-31
 ---
 
 # Architect Agent Workflow Skill
 
 Coordinate planning, delegation, and evaluation across architect and code agent workspaces.
+
+**Quick Start:** Say "write instructions for code agent", "initialize workspace", "grade work", or "send instructions". For automated setup, see [Quick Setup](#quick-setup-template-based).
 
 ## Table of Contents
 
@@ -35,40 +48,19 @@ Route requests based on user intent:
 
 ## Decision Tree
 
-```
-USER REQUEST
-    │
-    ├─► "write/create instructions" OR "delegate"
-    │   └─► Check: instructions/ dir exists?
-    │       ├─► Yes → Load guides/workflows/create-instructions.md
-    │       └─► No → Suggest workspace initialization first
-    │
-    ├─► "set up/initialize" architect workspace
-    │   └─► Check: directories DON'T exist?
-    │       ├─► Correct → Load guides/workflows/initialize-workspace.md
-    │       └─► Exist → Warn: already initialized
-    │
-    ├─► "grade" OR "evaluate" work
-    │   └─► Check: grades/ dir exists?
-    │       ├─► Yes → Load guides/workflows/grade-work.md
-    │       └─► No → Suggest workspace initialization first
-    │
-    ├─► "send instructions" to code agent
-    │   └─► Load guides/workflows/send-instructions.md
-    │       └─► Use simple bash copy (DO NOT spawn agents)
-    │
-    ├─► "verify" OR "test hooks/plugins"
-    │   └─► Load references/workspace_verification_protocol.md
-    │
-    ├─► "OpenCode" OR "dual-mode"
-    │   └─► Load references/opencode_integration_quickstart.md
-    │
-    ├─► "permissions" OR "settings.local.json"
-    │   └─► Load references/permissions_setup_protocol.md
-    │
-    └─► "upgrade" OR "migrate"
-        └─► Load references/upgrade.md
-```
+| User Intent | Pre-condition | Action |
+|-------------|---------------|--------|
+| "write/create instructions", "delegate" | `instructions/` exists | Load `guides/workflows/create-instructions.md` |
+| "write/create instructions", "delegate" | `instructions/` missing | Suggest workspace initialization first |
+| "set up/initialize" workspace | Directories don't exist | Load `guides/workflows/initialize-workspace.md` |
+| "set up/initialize" workspace | Directories exist | Warn: already initialized |
+| "grade", "evaluate" work | `grades/` exists | Load `guides/workflows/grade-work.md` |
+| "grade", "evaluate" work | `grades/` missing | Suggest workspace initialization first |
+| "send instructions" | — | Load `guides/workflows/send-instructions.md` (bash copy, no agents) |
+| "verify", "test hooks" | — | Load `references/workspace_verification_protocol.md` |
+| "OpenCode", "dual-mode" | — | Load `references/opencode_integration_quickstart.md` |
+| "permissions" | — | Load `references/permissions_setup_protocol.md` |
+| "upgrade", "migrate" | — | Load `references/upgrade.md` |
 
 ## Resource Loading Policy
 
@@ -92,20 +84,20 @@ USER REQUEST
 
 ## Critical Protocol: File Locations
 
-**YOU ARE THE ARCHITECT AGENT - You work in YOUR workspace, NOT the code agent workspace.**
+**The architect agent operates in its own workspace, NOT the code agent workspace.**
 
-| What | Where YOU Write | Where Code Agent Works |
-|------|----------------|----------------------|
-| Instructions | `YOUR_WORKSPACE/instructions/` | Reads from `debugging/instructions/` |
-| Human Instructions | `YOUR_WORKSPACE/human/` | N/A (for manual execution) |
-| Grades | `YOUR_WORKSPACE/grades/` | N/A |
-| Logs | N/A | Writes to `THEIR_WORKSPACE/debugging/logs/` |
+| Artifact | Architect Writes To | Code Agent Location |
+|----------|--------------------|--------------------|
+| Instructions | `[ARCHITECT]/instructions/` | Reads from `debugging/instructions/` |
+| Human Instructions | `[ARCHITECT]/human/` | N/A (for manual execution) |
+| Grades | `[ARCHITECT]/grades/` | N/A |
+| Logs | N/A | Writes to `[CODE_AGENT]/debugging/logs/` |
 
 **Human Instructions = Executable Documentation** (not summaries!)
 
 Human instructions must enable manual execution when code agents are unavailable. Include copy-pasteable commands, expected output, and troubleshooting. See `references/human_instruction_structure.md`.
 
-**If you find yourself writing to code agent's workspace, STOP.**
+**Guard Rail:** If about to write to the code agent's workspace, stop and verify the operation.
 
 ## Quick Setup (Template-Based)
 
@@ -135,21 +127,68 @@ cd ~/.claude/skills/architect-agent/templates/
 
 ## Reference Directory
 
-All detailed protocols are in `references/`:
+All detailed protocols are in `references/`. Load only what is needed for the current task.
+
+### Core References (Instruction & Grading)
 
 | Reference | Purpose |
 |-----------|---------|
-| `instruction_structure.md` | Complete instruction file template (for code agents) |
-| `human_instruction_structure.md` | Executable human instruction template (for manual execution) |
+| `instruction_structure.md` | Code agent instruction template |
+| `human_instruction_structure.md` | Human-executable instruction template |
 | `grading_rubrics.md` | 6-category grading criteria |
+| `instruction_grading_workflow.md` | Full grading workflow |
 | `decision_types.md` | decision, rationale, investigation, verification, deviation, milestone |
-| `pre_work_checklist.md` | Code agent pre-work verification |
-| `testing_protocol.md` | Progressive testing requirements |
-| `logging_protocol.md` | Hybrid logging v2.0 details |
-| `permissions_setup_protocol.md` | Cross-workspace permissions |
-| `workspace_verification_protocol.md` | Setup verification procedure |
-| `opencode_integration_quickstart.md` | Dual-mode (Claude Code + OpenCode) |
 | `file_naming.md` | Timestamp and naming conventions |
+
+### Setup & Configuration
+
+| Reference | Purpose |
+|-----------|---------|
+| `installation.md` | Skill installation guide |
+| `quick_start.md` | Fast-track setup |
+| `workspace_setup_complete.md` | Full workspace initialization |
+| `workspace_verification_protocol.md` | Verify setup is correct |
+| `permissions_setup_protocol.md` | Cross-workspace permissions |
+| `upgrade.md` | Upgrade to latest version |
+
+### Logging & Debugging
+
+| Reference | Purpose |
+|-----------|---------|
+| `logging_protocol.md` | Hybrid logging v2.0 |
+| `hybrid_logging_protocol.md` | Detailed hybrid logging spec |
+| `hook_configuration_critical.md` | Hook setup requirements |
+| `hook_logger_enhancements.md` | Hook logger improvements |
+| `pre_work_checklist.md` | Code agent pre-work verification |
+| `get_unstuck_protocol.md` | Recovery from blockers |
+| `resilience_protocol.md` | Error recovery patterns |
+| `testing_protocol.md` | Progressive testing requirements |
+
+### OpenCode Integration
+
+| Reference | Purpose |
+|-----------|---------|
+| `opencode_integration_quickstart.md` | Dual-mode quick start |
+| `opencode_setup_guide.md` | Full OpenCode setup |
+| `opencode_migration_guide.md` | Migrate to OpenCode |
+| `opencode_logging_protocol.md` | OpenCode-specific logging |
+| `opencode_wrapper_setup.md` | Wrapper script setup |
+| `claude_vs_opencode_comparison.md` | Feature comparison |
+
+### Agent Configuration
+
+| Reference | Purpose |
+|-----------|---------|
+| `agent_specialization.md` | Agent role configuration |
+| `code_agent_claude_template.md` | CLAUDE.md template for code agents |
+| `code_agent_agents_template.md` | AGENTS.md template for code agents |
+
+### Project Management
+
+| Reference | Purpose |
+|-----------|---------|
+| `git_pr_management.md` | Git and PR workflow |
+| `ticket_tracking_pr_management.md` | Ticket and PR tracking |
 
 ## Guides Directory
 
@@ -161,5 +200,17 @@ Step-by-step workflows in `guides/workflows/`:
 | `grade-work.md` | "grade the code agent's work" |
 | `send-instructions.md` | "send instructions to code agent" |
 | `initialize-workspace.md` | "set up architect agent workspace" |
+
+### Templates
+
+Ready-to-use workspace templates in `templates/`:
+
+| Template | Purpose |
+|----------|---------|
+| `setup-workspace.sh` | Automated workspace creation script |
+| `architect-workspace/` | Complete architect agent workspace template |
+| `code-agent-workspace/` | Complete code agent workspace template |
+
+**See:** `templates/README.md` for usage instructions.
 
 ---

--- a/evaluation-report.md
+++ b/evaluation-report.md
@@ -1,0 +1,589 @@
+# Skill Evaluation Report: architect-agent
+
+**Evaluated:** 2025-12-31
+**Files Reviewed:** SKILL.md, guides/workflows/*.md, references/*.md (30+ files), examples/human-instructions/*.md, templates/*.sh
+
+---
+
+## Overall Score: 88/100
+
+| Pillar | Score | Max |
+|--------|-------|-----|
+| Progressive Disclosure Architecture | 26 | 30 |
+| Ease of Use | 23 | 25 |
+| Spec Compliance | 13 | 15 |
+| Writing Style | 9 | 10 |
+| Utility | 19 | 20 |
+| Modifiers | +6 | ±15 |
+
+**Grade: B**
+
+**Code Quality: 22/25** (scripts present)
+
+---
+
+## Executive Summary
+
+The architect-agent skill is a well-structured, production-ready skill that effectively coordinates multi-agent workflows. Its primary strength is excellent discoverability with 5+ trigger phrases and clear intent classification. The most impactful improvement would be adding optional fields (allowed-tools, metadata with version) and exposing more references in the main SKILL.md to improve navigation. This skill is ready for production use with minor enhancements recommended.
+
+---
+
+## Detailed Scores
+
+### Progressive Disclosure Architecture (26/30)
+
+| Criterion | Score | Max | Assessment |
+|-----------|-------|-----|------------|
+| Token Economy | 9 | 10 | Excellent conciseness, tables used efficiently, no fluff |
+| Layered Structure | 8 | 10 | Good separation but 30+ references with only 11 surfaced in SKILL.md |
+| Reference Depth | 5 | 5 | All references one level deep, flat structure |
+| Navigation Signals | 4 | 5 | Has TOC, decision tree readable but could be a table |
+
+### Ease of Use (23/25)
+
+| Criterion | Score | Max | Assessment |
+|-----------|-------|-----|------------|
+| Metadata Quality | 9 | 10 | 5 trigger phrases in description, excellent but no optional fields |
+| Discoverability | 5 | 6 | Clear triggers but many references hidden from main view |
+| Terminology Consistency | 4 | 4 | Consistent use of architect/code agent, workspace, instructions |
+| Workflow Clarity | 5 | 5 | Clear numbered steps, checklists, conditional paths |
+
+### Spec Compliance (13/15)
+
+| Criterion | Score | Max | Assessment |
+|-----------|-------|-----|------------|
+| Frontmatter Validity | 5 | 5 | Valid YAML, both required fields present |
+| Name Conventions | 4 | 4 | Hyphen-case, lowercase, matches directory |
+| Description Quality | 4 | 4 | Third-person, 5 trigger phrases, explains what AND when |
+| Optional Fields | 0 | 2 | No allowed-tools, no metadata, no license |
+
+### Writing Style (9/10)
+
+| Criterion | Score | Max | Assessment |
+|-----------|-------|-----|------------|
+| Voice & Tense | 3 | 4 | Mostly imperative, "YOU ARE THE ARCHITECT" is second-person |
+| Objectivity | 3 | 3 | No marketing language, purely instructional |
+| Conciseness | 3 | 3 | Every sentence adds value, Claude-appropriate density |
+
+### Utility (19/20)
+
+| Criterion | Score | Max | Assessment |
+|-----------|-------|-----|------------|
+| Problem-Solving Power | 7 | 8 | Addresses real capability gap in multi-agent coordination |
+| Degrees of Freedom | 5 | 5 | Flexible for architecture, tight for file locations |
+| Feedback Loops | 4 | 4 | Pre-work checklists, grading rubrics, validation steps |
+| Examples & Templates | 3 | 3 | Full workspace templates, GOOD/BAD examples |
+
+### Modifiers Applied (+6)
+
+**Penalties:** None
+
+**Bonuses:**
+- Copy-paste checklists: +2 (multiple workflow checklists)
+- Self-documenting scripts: +2 (setup-workspace.sh has usage info)
+- Explicit scope boundaries: +1 ("DO NOT Trigger For" section)
+- Counter-examples: +1 (BAD-vague-summary.md)
+
+---
+
+## Critical Issues (Top 7)
+
+### Issue 1: No Optional Fields in Frontmatter
+
+**Severity:** Medium
+**Location:** SKILL.md:frontmatter
+**Pillar Affected:** Spec Compliance
+
+**Problem:** Skill doesn't use optional fields like `allowed-tools` or `metadata`, missing opportunities for version tracking and tool restrictions.
+
+**Current:**
+```yaml
+---
+name: architect-agent
+description: Coordinates planning, delegation, and evaluation...
+---
+```
+
+**Suggested Rewrite:**
+```yaml
+---
+name: architect-agent
+description: Coordinates planning, delegation, and evaluation across architect and code agent workspaces. Use when asked to "write instructions for code agent", "initialize architect workspace", "grade code agent work", "send instructions", or "verify code agent setup".
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+metadata:
+  version: 3.0.0
+  last-updated: 2025-12-31
+---
+```
+
+**Impact:** +2 points (optional fields + version bonus)
+
+---
+
+### Issue 2: Hidden References Not Surfaced
+
+**Severity:** Medium
+**Location:** SKILL.md:Reference Directory
+**Pillar Affected:** PDA, Ease of Use
+
+**Problem:** Only 11 of 30+ references are listed in the Reference Directory table. Critical files like `resilience_protocol.md`, `quick_start.md`, and `agent_specialization.md` are not discoverable from SKILL.md.
+
+**Current:**
+```markdown
+## Reference Directory
+
+All detailed protocols are in `references/`:
+
+| Reference | Purpose |
+|-----------|---------|
+| `instruction_structure.md` | Complete instruction file template (for code agents) |
+... (11 total)
+```
+
+**Suggested Rewrite:**
+```markdown
+## Reference Directory
+
+All detailed protocols are in `references/`:
+
+### Core References (Always Relevant)
+
+| Reference | Purpose |
+|-----------|---------|
+| `instruction_structure.md` | Code agent instruction template |
+| `human_instruction_structure.md` | Human-executable instruction template |
+| `grading_rubrics.md` | 6-category grading criteria |
+| `file_naming.md` | Timestamp and naming conventions |
+
+### Setup & Configuration
+
+| Reference | Purpose |
+|-----------|---------|
+| `installation.md` | Skill installation guide |
+| `quick_start.md` | Fast-track setup guide |
+| `workspace_setup_complete.md` | Full workspace initialization |
+| `permissions_setup_protocol.md` | Cross-workspace permissions |
+
+### Logging & Debugging
+
+| Reference | Purpose |
+|-----------|---------|
+| `logging_protocol.md` | Hybrid logging v2.0 |
+| `hook_configuration_critical.md` | Hook setup requirements |
+| `get_unstuck_protocol.md` | Recovery from blockers |
+| `resilience_protocol.md` | Error recovery patterns |
+
+### Advanced Topics
+
+| Reference | Purpose |
+|-----------|---------|
+| `opencode_integration_quickstart.md` | Dual-mode setup |
+| `agent_specialization.md` | Agent role configuration |
+```
+
+**Impact:** +3 points (layered structure, discoverability)
+
+---
+
+### Issue 3: Second-Person Voice in Critical Protocol
+
+**Severity:** Low
+**Location:** SKILL.md:93-108
+**Pillar Affected:** Writing Style
+
+**Problem:** Section uses second-person "YOU" which is inconsistent with imperative voice best practices.
+
+**Current:**
+```markdown
+## Critical Protocol: File Locations
+
+**YOU ARE THE ARCHITECT AGENT - You work in YOUR workspace, NOT the code agent workspace.**
+
+| What | Where YOU Write | Where Code Agent Works |
+```
+
+**Suggested Rewrite:**
+```markdown
+## Critical Protocol: File Locations
+
+**The architect agent works in its own workspace, NOT the code agent workspace.**
+
+| What | Architect Writes To | Code Agent Workspace |
+|------|-------------------|---------------------|
+| Instructions | `[ARCHITECT]/instructions/` | Reads from `debugging/instructions/` |
+| Human Instructions | `[ARCHITECT]/human/` | N/A (for manual execution) |
+| Grades | `[ARCHITECT]/grades/` | N/A |
+| Logs | N/A | Writes to `debugging/logs/` |
+
+**Guard Rail:** If writing to code agent's workspace, stop and verify the operation.
+```
+
+**Impact:** +1 point (voice & tense)
+
+---
+
+### Issue 4: Decision Tree Could Be a Table
+
+**Severity:** Low
+**Location:** SKILL.md:36-71
+**Pillar Affected:** PDA (Navigation Signals)
+
+**Problem:** ASCII art decision tree is 35 lines long and harder to scan than a table. Tables are more grep-friendly and fit the document style.
+
+**Current:**
+```
+USER REQUEST
+    │
+    ├─► "write/create instructions" OR "delegate"
+    │   └─► Check: instructions/ dir exists?
+    │       ├─► Yes → Load guides/workflows/create-instructions.md
+    │       └─► No → Suggest workspace initialization first
+    ... (35 lines)
+```
+
+**Suggested Rewrite:**
+```markdown
+## Decision Tree
+
+| User Intent | Pre-condition | Action |
+|-------------|---------------|--------|
+| "write/create instructions", "delegate" | `instructions/` exists | Load `guides/workflows/create-instructions.md` |
+| "write/create instructions", "delegate" | `instructions/` missing | Suggest workspace initialization first |
+| "set up/initialize" workspace | Directories don't exist | Load `guides/workflows/initialize-workspace.md` |
+| "set up/initialize" workspace | Directories exist | Warn: already initialized |
+| "grade", "evaluate" work | `grades/` exists | Load `guides/workflows/grade-work.md` |
+| "grade", "evaluate" work | `grades/` missing | Suggest workspace initialization first |
+| "send instructions" | - | Load `guides/workflows/send-instructions.md` |
+| "verify", "test hooks" | - | Load `references/workspace_verification_protocol.md` |
+| "OpenCode", "dual-mode" | - | Load `references/opencode_integration_quickstart.md` |
+| "permissions" | - | Load `references/permissions_setup_protocol.md` |
+| "upgrade", "migrate" | - | Load `references/upgrade.md` |
+```
+
+**Impact:** +1 point (navigation signals)
+
+---
+
+### Issue 5: Missing Version Information
+
+**Severity:** Low
+**Location:** SKILL.md:frontmatter
+**Pillar Affected:** Spec Compliance
+
+**Problem:** No version tracking makes it difficult to know which version is deployed or to track changes over time.
+
+**Current:** No version information anywhere in frontmatter.
+
+**Suggested Rewrite:** Add to frontmatter (see Issue 1), plus add to SKILL.md body:
+
+```markdown
+---
+
+**Version:** 3.0.0 | [Changelog](references/CHANGELOG.md)
+```
+
+**Impact:** +1 point (version in metadata bonus)
+
+---
+
+### Issue 6: No Quick Start in SKILL.md Overview
+
+**Severity:** Low
+**Location:** SKILL.md:top
+**Pillar Affected:** Ease of Use
+
+**Problem:** New users must read through intent classification before understanding what this skill does. A 2-sentence quick start would help.
+
+**Current:**
+```markdown
+# Architect Agent Workflow Skill
+
+Coordinate planning, delegation, and evaluation across architect and code agent workspaces.
+
+## Table of Contents
+...
+```
+
+**Suggested Rewrite:**
+```markdown
+# Architect Agent Workflow Skill
+
+Coordinate planning, delegation, and evaluation across architect and code agent workspaces.
+
+**Quick Start:** Run `/architect-agent` with one of: "write instructions", "initialize workspace", "grade work", or "send instructions". See [Quick Setup](#quick-setup-template-based) for template-based initialization.
+
+## Table of Contents
+...
+```
+
+**Impact:** +1 point (workflow clarity, first-time user experience)
+
+---
+
+### Issue 7: Guides Directory Could Link to Templates
+
+**Severity:** Low
+**Location:** SKILL.md:154-163
+**Pillar Affected:** Utility
+
+**Problem:** Guides Directory lists workflows but doesn't mention the relationship to templates. Users may not realize templates exist.
+
+**Current:**
+```markdown
+## Guides Directory
+
+Step-by-step workflows in `guides/workflows/`:
+
+| Guide | Trigger |
+|-------|---------|
+| `create-instructions.md` | "write instructions for code agent" |
+...
+```
+
+**Suggested Rewrite:**
+```markdown
+## Guides Directory
+
+Step-by-step workflows in `guides/workflows/`:
+
+| Guide | Trigger |
+|-------|---------|
+| `create-instructions.md` | "write instructions for code agent" |
+| `grade-work.md` | "grade the code agent's work" |
+| `send-instructions.md` | "send instructions to code agent" |
+| `initialize-workspace.md` | "set up architect agent workspace" |
+
+**Templates:** Use `templates/setup-workspace.sh` for automated workspace creation. See `templates/README.md`.
+```
+
+**Impact:** +0.5 points (examples & templates discoverability)
+
+---
+
+## General Recommendations
+
+1. **Add optional fields to frontmatter:** Include `allowed-tools` to document which tools this skill uses, and `metadata.version` for tracking.
+
+2. **Surface all references:** Create categorized sections in Reference Directory to expose all 30+ reference files, not just 11.
+
+3. **Standardize voice:** Replace "YOU ARE THE ARCHITECT" with imperative/third-person phrasing for consistency.
+
+4. **Add quick start line:** One sentence at the top helps new users understand the skill immediately.
+
+5. **Consider a CHANGELOG.md:** Track changes across versions for users who need to understand updates.
+
+---
+
+## Score Improvement Roadmap
+
+| If You Address... | Estimated Score |
+|-------------------|-----------------|
+| Top 3 issues (frontmatter, references, voice) | 93/100 |
+| All 7 issues | 95/100 |
+
+---
+
+## Grade Scale
+
+| Grade | Score | Description |
+|-------|-------|-------------|
+| A | 90-100 | Production-ready |
+| B | 80-89 | Good, minor work |
+| C | 70-79 | Adequate, gaps |
+| D | 60-69 | Needs work |
+| F | <60 | Major revision |
+
+---
+
+## Code Quality Assessment (22/25)
+
+Scripts reviewed: `templates/setup-workspace.sh`, `templates/verify-workspace.sh`, logging scripts
+
+| Criterion | Score | Max | Assessment |
+|-----------|-------|-----|------------|
+| Error Handling | 7 | 8 | `set -e`, validates inputs, clear error messages |
+| Documentation | 6 | 6 | Usage info, inline comments, version header |
+| Dependency Management | 4 | 5 | No install commands, assumes bash/git available |
+| Script Organization | 5 | 6 | Logical structure, colored output, but long functions |
+
+---
+
+## JSON Output
+
+```json
+{
+  "skill_name": "architect-agent",
+  "evaluated_at": "2025-12-31T12:00:00Z",
+  "files_reviewed": ["SKILL.md", "guides/workflows/create-instructions.md", "guides/workflows/grade-work.md", "guides/workflows/send-instructions.md", "guides/workflows/initialize-workspace.md", "references/instruction_structure.md", "references/human_instruction_structure.md", "examples/human-instructions/GOOD-database-migration.md", "examples/human-instructions/BAD-vague-summary.md", "templates/setup-workspace.sh"],
+
+  "scores": {
+    "pda": {
+      "total": 26,
+      "max": 30,
+      "breakdown": {
+        "token_economy": { "score": 9, "max": 10, "assessment": "Excellent conciseness, tables used efficiently" },
+        "layered_structure": { "score": 8, "max": 10, "assessment": "Good but 30+ refs with only 11 surfaced" },
+        "reference_depth": { "score": 5, "max": 5, "assessment": "All references one level deep" },
+        "navigation_signals": { "score": 4, "max": 5, "assessment": "Has TOC, decision tree could be table" }
+      }
+    },
+    "ease_of_use": {
+      "total": 23,
+      "max": 25,
+      "breakdown": {
+        "metadata_quality": { "score": 9, "max": 10, "assessment": "5 trigger phrases, no optional fields" },
+        "discoverability": { "score": 5, "max": 6, "assessment": "Clear triggers but hidden references" },
+        "terminology_consistency": { "score": 4, "max": 4, "assessment": "Consistent terminology throughout" },
+        "workflow_clarity": { "score": 5, "max": 5, "assessment": "Clear steps, checklists, conditional paths" }
+      }
+    },
+    "spec_compliance": {
+      "total": 13,
+      "max": 15,
+      "breakdown": {
+        "frontmatter_validity": { "score": 5, "max": 5, "assessment": "Valid YAML, required fields present" },
+        "name_conventions": { "score": 4, "max": 4, "assessment": "Hyphen-case, matches directory" },
+        "description_quality": { "score": 4, "max": 4, "assessment": "5 trigger phrases, third-person" },
+        "optional_fields": { "score": 0, "max": 2, "assessment": "No optional fields used" }
+      }
+    },
+    "writing_style": {
+      "total": 9,
+      "max": 10,
+      "breakdown": {
+        "voice_and_tense": { "score": 3, "max": 4, "assessment": "Mostly imperative, some second-person" },
+        "objectivity": { "score": 3, "max": 3, "assessment": "No marketing language" },
+        "conciseness": { "score": 3, "max": 3, "assessment": "Every sentence adds value" }
+      }
+    },
+    "utility": {
+      "total": 19,
+      "max": 20,
+      "breakdown": {
+        "problem_solving_power": { "score": 7, "max": 8, "assessment": "Addresses real multi-agent coordination gap" },
+        "degrees_of_freedom": { "score": 5, "max": 5, "assessment": "Appropriate flexibility and constraints" },
+        "feedback_loops": { "score": 4, "max": 4, "assessment": "Checklists, grading rubrics, validation" },
+        "examples_and_templates": { "score": 3, "max": 3, "assessment": "Full templates, GOOD/BAD examples" }
+      }
+    }
+  },
+
+  "modifiers": {
+    "penalties": [],
+    "bonuses": [
+      { "name": "copy_paste_checklists", "points": 2 },
+      { "name": "self_documenting_scripts", "points": 2 },
+      { "name": "explicit_scope_boundaries", "points": 1 },
+      { "name": "counter_examples", "points": 1 }
+    ],
+    "net": 6
+  },
+
+  "final_score": 88,
+  "grade": "B",
+
+  "critical_issues": [
+    {
+      "rank": 1,
+      "title": "No optional fields in frontmatter",
+      "severity": "Medium",
+      "location": "SKILL.md:frontmatter",
+      "pillar": "Spec Compliance",
+      "problem": "Missing allowed-tools and metadata.version",
+      "current": "name: architect-agent\ndescription: ...",
+      "suggested": "name: architect-agent\ndescription: ...\nallowed-tools:\n  - Read\n  - Write\n  - Bash\nmetadata:\n  version: 3.0.0",
+      "impact": "+2 points"
+    },
+    {
+      "rank": 2,
+      "title": "Hidden references not surfaced",
+      "severity": "Medium",
+      "location": "SKILL.md:Reference Directory",
+      "pillar": "PDA",
+      "problem": "Only 11 of 30+ references listed",
+      "current": "11 references in table",
+      "suggested": "Categorized sections for all references",
+      "impact": "+3 points"
+    },
+    {
+      "rank": 3,
+      "title": "Second-person voice in Critical Protocol",
+      "severity": "Low",
+      "location": "SKILL.md:93-108",
+      "pillar": "Writing Style",
+      "problem": "Uses YOU ARE instead of imperative",
+      "current": "YOU ARE THE ARCHITECT AGENT",
+      "suggested": "The architect agent works in its own workspace",
+      "impact": "+1 point"
+    },
+    {
+      "rank": 4,
+      "title": "Decision tree could be a table",
+      "severity": "Low",
+      "location": "SKILL.md:36-71",
+      "pillar": "PDA",
+      "problem": "ASCII art is 35 lines, harder to scan",
+      "current": "ASCII decision tree",
+      "suggested": "Table with Intent, Pre-condition, Action columns",
+      "impact": "+1 point"
+    },
+    {
+      "rank": 5,
+      "title": "Missing version information",
+      "severity": "Low",
+      "location": "SKILL.md:frontmatter",
+      "pillar": "Spec Compliance",
+      "problem": "No version tracking",
+      "current": "No version",
+      "suggested": "metadata.version: 3.0.0",
+      "impact": "+1 point"
+    },
+    {
+      "rank": 6,
+      "title": "No quick start in overview",
+      "severity": "Low",
+      "location": "SKILL.md:top",
+      "pillar": "Ease of Use",
+      "problem": "New users must read through to understand",
+      "current": "Direct to TOC",
+      "suggested": "Add Quick Start one-liner after description",
+      "impact": "+1 point"
+    },
+    {
+      "rank": 7,
+      "title": "Guides don't link to templates",
+      "severity": "Low",
+      "location": "SKILL.md:154-163",
+      "pillar": "Utility",
+      "problem": "Templates not discoverable from guides section",
+      "current": "No mention of templates",
+      "suggested": "Add templates reference below guides table",
+      "impact": "+0.5 points"
+    }
+  ],
+
+  "recommendations": [
+    "Add optional fields (allowed-tools, metadata.version) to frontmatter",
+    "Surface all references in categorized sections",
+    "Standardize to imperative voice throughout",
+    "Add quick start line at top for new users",
+    "Consider adding CHANGELOG.md for version tracking"
+  ],
+
+  "code_quality": {
+    "total": 22,
+    "max": 25,
+    "breakdown": {
+      "error_handling": { "score": 7, "max": 8, "assessment": "set -e, validates inputs, clear errors" },
+      "documentation": { "score": 6, "max": 6, "assessment": "Usage info, inline comments, version" },
+      "dependency_management": { "score": 4, "max": 5, "assessment": "Assumes bash/git, no install cmds" },
+      "script_organization": { "score": 5, "max": 6, "assessment": "Good structure, some long functions" }
+    }
+  }
+}
+```


### PR DESCRIPTION
## Fixes #40

## Problem

Skill evaluation using the improving-skills skill scored 88/100 (Grade B). Several improvements were identified to achieve A grade (93+).

## Solution

Implemented all 6 critical improvements:

1. **Added optional frontmatter fields** - `allowed-tools` and `metadata` with version/date
2. **Added quick start line** - After description for immediate guidance
3. **Converted decision tree to table format** - Reduced token usage, improved readability
4. **Fixed second-person voice** - Changed 'YOU ARE THE ARCHITECT' to 'The architect agent operates'
5. **Expanded Reference Directory** - From 11 to 30+ files in 6 categorized sections
6. **Added Templates subsection** - Links to templates/ with usage instructions

## Testing

- Verified SKILL.md renders correctly
- All internal links valid
- Frontmatter parses correctly

## Files Changed

- `SKILL.md` - All improvements applied
- `evaluation-report.md` - NEW: Full evaluation report with scoring breakdown